### PR TITLE
Fix: Add .nojekyll to static dir for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,6 +38,10 @@ jobs:
       - name: Build WASM
         run: wasm-pack build --target web --out-dir static/pkg
 
+      # Create .nojekyll file
+      - name: Create .nojekyll file
+        run: touch static/.nojekyll
+
       # 5. `static` ディレクトリの内容を `gh-pages` ブランチにデプロイする
       #    peaceiris/actions-gh-pages という便利なアクションを利用する
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
This commit modifies the GitHub Actions deployment workflow to create a `.nojekyll` file in the `static/` directory before deploying to GitHub Pages.

The presence of a `.nojekyll` file disables Jekyll processing on GitHub Pages, which can sometimes interfere with the serving of files, especially those in apparent subdirectories like `pkg/`. This is intended to resolve the 404 error you encountered for `/pkg/solver.js` when the application is deployed.